### PR TITLE
Use lifecycle node

### DIFF
--- a/audio_capture/CMakeLists.txt
+++ b/audio_capture/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(audio_common_msgs REQUIRED)
 find_package(diagnostic_updater REQUIRED)
 find_package(PkgConfig)
@@ -28,6 +29,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS} ${GST1.
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
+  rclcpp_lifecycle
   audio_common_msgs
   diagnostic_updater
 )

--- a/audio_capture/launch/capture_portaudio.launch.py
+++ b/audio_capture/launch/capture_portaudio.launch.py
@@ -1,0 +1,53 @@
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import LifecycleNode
+
+
+def generate_launch_description() -> LaunchDescription:
+    _bitrate = LaunchConfiguration('bitrate')
+    _channels = LaunchConfiguration('channels')
+    _sample_rate = LaunchConfiguration('sample_rate')
+    _desired_rate = LaunchConfiguration('desired_rate')
+    _sample_format = LaunchConfiguration('sample_format')
+    _ns = LaunchConfiguration('ns')
+    _audio_topic = LaunchConfiguration('audio_topic')
+
+    _format_launch_arg = DeclareLaunchArgument('format', default_value='mp3')
+    _bitrate_launch_arg = DeclareLaunchArgument('bitrate', default_value='128')
+    _channels_launch_arg = DeclareLaunchArgument('channels', default_value='1')
+    _sample_rate_launch_arg = DeclareLaunchArgument('sample_rate', default_value='16000')
+    _desired_rate_launch_arg = DeclareLaunchArgument('desired_rate', default_value='100.0')
+    _sample_format_launch_arg = DeclareLaunchArgument('sample_format', default_value='S16LE')
+    _ns_launch_arg = DeclareLaunchArgument('ns', default_value='audio')
+    _audio_topic_launch_arg = DeclareLaunchArgument('audio_topic', default_value='audio')
+
+    _audio_capture_node = LifecycleNode(
+        package='audio_capture',
+        name='audio_capture',
+        executable='audio_capture_portaudio_node',
+        namespace=_ns,
+        autostart=True,
+        remappings=[
+            ('audio', _audio_topic),
+        ],
+        parameters=[{
+            'bitrate': _bitrate,
+            'channels': _channels,
+            'sample_rate': _sample_rate,
+            'sample_format': _sample_format,
+            'desired_rate': _desired_rate,
+        }],
+    )
+
+    return LaunchDescription([
+        _format_launch_arg,
+        _bitrate_launch_arg,
+        _channels_launch_arg,
+        _sample_rate_launch_arg,
+        _desired_rate_launch_arg,
+        _sample_format_launch_arg,
+        _ns_launch_arg,
+        _audio_topic_launch_arg,
+        _audio_capture_node,
+    ])

--- a/audio_capture/package.xml
+++ b/audio_capture/package.xml
@@ -29,6 +29,7 @@
    <build_depend>libgstreamer1.0-dev</build_depend>
    <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
    <depend>portaudio19-dev</depend>
+   <depend>rclcpp_lifecycle</depend>
 
    <exec_depend>audio_common_msgs</exec_depend>
    <exec_depend>diagnostic_updater</exec_depend>

--- a/audio_capture/src/port_audio_capture.cpp
+++ b/audio_capture/src/port_audio_capture.cpp
@@ -21,8 +21,10 @@
 #include <boost/thread.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_updater/publisher.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include "audio_common_msgs/msg/audio_data.hpp"
 #include "audio_common_msgs/msg/audio_data_stamped.hpp"
@@ -30,28 +32,21 @@
 
 namespace audio_capture
 {
-class PortAudioCaptureNode : public rclcpp::Node
+class PortAudioCaptureNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
   PortAudioCaptureNode(const rclcpp::NodeOptions & options)
-  : Node("audio_capture_node", options), updater_(this), _desired_rate(-1.0)
+  : rclcpp_lifecycle::LifecycleNode("audio_capture_node", options), updater_(this), _desired_rate(-1.0)
   {
-    PaError err = Pa_Initialize();
-    if (err != paNoError) {
-      RCLCPP_ERROR(this->get_logger(), "PortAudio error: %s", Pa_GetErrorText(err));
-      exitOnMainThread(1);
-    }
-
     this->declare_parameter<std::string>("sample_format", "S16LE");
-    this->get_parameter("sample_format", _sample_format);
 
     this->declare_parameter<int>("channels", 1);
     this->declare_parameter<int>("sample_rate", 16000);
     this->declare_parameter<int>("bitrate", 192);
     this->declare_parameter<double>("desired_rate", 100.0);
-    this->get_parameter("channels", _channels);
-    this->get_parameter("sample_rate", _sample_rate);
-    this->get_parameter("bitrate", _bitrate);
+
+    this->declare_parameter<double>("diagnostic_tolerance", 0.1);
+
     this->get_parameter("desired_rate", _desired_rate);
 
     _pub = this->create_publisher<audio_common_msgs::msg::AudioData>("audio", 10);
@@ -61,8 +56,9 @@ public:
     rclcpp::Publisher<audio_common_msgs::msg::AudioDataStamped>::SharedPtr pub_stamped =
       this->create_publisher<audio_common_msgs::msg::AudioDataStamped>("audio_stamped", 10);
 
-    this->declare_parameter<double>("diagnostic_tolerance", 0.1);
     auto tolerance = this->get_parameter("diagnostic_tolerance").as_double();
+
+    _last_publish_time_ = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
 
     updater_.setHardwareID("microphone");
     _diagnosed_pub_stamped =
@@ -70,13 +66,8 @@ public:
         pub_stamped, updater_, diagnostic_updater::FrequencyStatusParam(&_desired_rate, &_desired_rate, tolerance, 10),
         diagnostic_updater::TimeStampStatusParam());
 
-    _stream = nullptr;
-    openStream();
-
-    _gst_thread = boost::thread(boost::bind(&PortAudioCaptureNode::captureLoop, this));
-
-    _timer_info = rclcpp::create_timer(this, get_clock(), std::chrono::seconds(5), [this] { publishInfo(); });
-    publishInfo();
+    _auto_recovery_timer =
+      create_wall_timer(std::chrono::duration<double>(1.0), [this] { autoRecoveryTrigger(); });
   }
 
   void publishInfo()
@@ -99,14 +90,86 @@ public:
     Pa_Terminate();
   }
 
-  void exitOnMainThread(int code) { exit(code); }
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+  auto on_configure(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
+    PaError err = Pa_Initialize();
+    if (err != paNoError) {
+      RCLCPP_ERROR(this->get_logger(), "PortAudio error: %s", Pa_GetErrorText(err));
+      return CallbackReturn::FAILURE;
+    }
+    this->get_parameter("sample_format", _sample_format);
+    this->get_parameter("channels", _channels);
+    this->get_parameter("sample_rate", _sample_rate);
+    this->get_parameter("bitrate", _bitrate);
+
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_activate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    _stream = nullptr;
+    if (!openStream()) {
+      return CallbackReturn::FAILURE;
+    }
+
+    _gst_thread = boost::thread(boost::bind(&PortAudioCaptureNode::captureLoop, this));
+
+    _timer_info = rclcpp::create_timer(this, get_clock(), std::chrono::seconds(5), [this] { publishInfo(); });
+    publishInfo();
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
+    if (_gst_thread.joinable()) {
+      _gst_thread.join();
+    }
+    if (_stream) {
+      Pa_StopStream(_stream);
+      Pa_CloseStream(_stream);
+      _stream = nullptr;
+    }
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    _last_publish_time_ = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_error(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    if (_gst_thread.joinable()) {
+      _gst_thread.join();
+    }
+    if (_stream) {
+      Pa_StopStream(_stream);
+      Pa_CloseStream(_stream);
+      _stream = nullptr;
+    }
+    return CallbackReturn::SUCCESS;
+  }
+
+  void autoRecoveryTrigger()
+  {
+    if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+      trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+    } else if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+      if (get_clock()->now() - _last_publish_time_ > rclcpp::Duration::from_seconds(1.0)) {
+        RCLCPP_WARN(this->get_logger(), "No audio data published for 1 second, deactivating.");
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+      }
+    } else if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      if (_last_publish_time_ != rclcpp::Time(0, 0, this->get_clock()->get_clock_type())) {
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP);
+      } else {
+        RCLCPP_INFO(this->get_logger(), "Reactivating.");
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+      }
+    }
+  }
 
   void publish(const audio_common_msgs::msg::AudioData & msg) { _pub->publish(msg); }
 
   void publishStamped(const audio_common_msgs::msg::AudioDataStamped & msg) { _diagnosed_pub_stamped->publish(msg); }
 
 private:
-  void openStream()
+  auto openStream() -> bool
   {
     PaStreamParameters inputParameters;
     inputParameters.device = Pa_GetDefaultInputDevice();
@@ -125,7 +188,7 @@ private:
       inputParameters.sampleFormat = paInt24;
     } else {
       RCLCPP_ERROR(this->get_logger(), "Unsupported sample format: %s", _sample_format.c_str());
-      exitOnMainThread(1);
+      return false;
     }
     inputParameters.suggestedLatency = Pa_GetDeviceInfo(inputParameters.device)->defaultLowInputLatency;
     inputParameters.hostApiSpecificStreamInfo = nullptr;
@@ -139,14 +202,16 @@ private:
 
     if (err != paNoError) {
       RCLCPP_ERROR(this->get_logger(), "PortAudio error: %s", Pa_GetErrorText(err));
-      exitOnMainThread(1);
+      return false;
     }
 
     err = Pa_StartStream(_stream);
     if (err != paNoError) {
       RCLCPP_ERROR(this->get_logger(), "PortAudio error: %s", Pa_GetErrorText(err));
-      exitOnMainThread(1);
+      return false;
     }
+
+    return true;
   }
 
   static int paCallback(
@@ -167,6 +232,7 @@ private:
 
     server->publish(msg);
     server->publishStamped(stamped_msg);
+    server->_last_publish_time_ = stamped_msg.header.stamp;
 
     return paContinue;
   }
@@ -182,6 +248,7 @@ private:
   rclcpp::Publisher<audio_common_msgs::msg::AudioInfo>::SharedPtr _pub_info;
 
   rclcpp::TimerBase::SharedPtr _timer_info;
+  rclcpp::TimerBase::SharedPtr _auto_recovery_timer;
 
   boost::thread _gst_thread;
 
@@ -193,6 +260,7 @@ private:
   double _desired_rate;
   std::shared_ptr<diagnostic_updater::DiagnosedPublisher<audio_common_msgs::msg::AudioDataStamped>>
     _diagnosed_pub_stamped;
+  rclcpp::Time _last_publish_time_;
 };
 }  // namespace audio_capture
 

--- a/audio_capture/src/port_audio_capture.cpp
+++ b/audio_capture/src/port_audio_capture.cpp
@@ -111,22 +111,17 @@ public:
       return CallbackReturn::FAILURE;
     }
 
-    _gst_thread = boost::thread(boost::bind(&PortAudioCaptureNode::captureLoop, this));
-
     _timer_info = rclcpp::create_timer(this, get_clock(), std::chrono::seconds(5), [this] { publishInfo(); });
     publishInfo();
     return CallbackReturn::SUCCESS;
   }
   auto on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
   {
-    if (_gst_thread.joinable()) {
-      _gst_thread.join();
-    }
     if (_stream) {
-      Pa_StopStream(_stream);
       Pa_CloseStream(_stream);
       _stream = nullptr;
     }
+    RCLCPP_INFO(this->get_logger(), "PortAudioCaptureNode deactivated, stream closed.");
     return CallbackReturn::SUCCESS;
   }
   auto on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
@@ -134,11 +129,7 @@ public:
     return CallbackReturn::SUCCESS;
   }
   auto on_error(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
-    if (_gst_thread.joinable()) {
-      _gst_thread.join();
-    }
     if (_stream) {
-      Pa_StopStream(_stream);
       Pa_CloseStream(_stream);
       _stream = nullptr;
     }
@@ -237,20 +228,11 @@ private:
     return paContinue;
   }
 
-  void captureLoop()
-  {
-    while (rclcpp::ok()) {
-      Pa_Sleep(100);
-    }
-  }
-
   rclcpp::Publisher<audio_common_msgs::msg::AudioData>::SharedPtr _pub;
   rclcpp::Publisher<audio_common_msgs::msg::AudioInfo>::SharedPtr _pub_info;
 
   rclcpp::TimerBase::SharedPtr _timer_info;
   rclcpp::TimerBase::SharedPtr _auto_recovery_timer;
-
-  boost::thread _gst_thread;
 
   PaStream * _stream;
   int _bitrate, _channels, _sample_rate;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

lifecycle node化して
何らかの原因でtopicがpublishされなくなったときに
portaudioの再接続を行うように

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- ref https://github.com/sbgisen/soar/issues/798

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

```bash
ros2 launch audio_capture capture_portaudio.launch.py bitrate:=512 sample_format:=S16LE sample_rate:=16000
```

実際に何が起きているかはわからないが、
とりあえずpipewireを強制再起動させる
```bash
systemctl --user restart pipewire pipewire-pulse
```

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
