### PR TITLE
Add pulseaudio capture node

### DIFF
--- a/audio_capture/CMakeLists.txt
+++ b/audio_capture/CMakeLists.txt
@@ -19,13 +19,16 @@ find_package(PkgConfig)
 pkg_check_modules(GST1.0 gstreamer-1.0 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
+pkg_check_modules(PULSE REQUIRED libpulse)
+pkg_check_modules(PULSE_SIMPLE REQUIRED libpulse-simple)
 
 add_library(${PROJECT_NAME} SHARED
   src/audio_capture_node.cpp
   src/port_audio_capture.cpp
+  src/pulse_audio_capture.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS} ${PORTAUDIO_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS} ${PORTAUDIO_INCLUDE_DIRS} ${PULSE_INCLUDE_DIRS} ${PULSE_SIMPLE_INCLUDE_DIRS})
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
@@ -34,7 +37,7 @@ ament_target_dependencies(${PROJECT_NAME}
   diagnostic_updater
 )
 
-target_link_libraries(${PROJECT_NAME} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES} ${PORTAUDIO_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${PULSE_LIBRARIES} ${PULSE_SIMPLE_LIBRARIES})
 
 rclcpp_components_register_node(
   ${PROJECT_NAME}
@@ -46,6 +49,11 @@ rclcpp_components_register_node(
   PLUGIN "audio_capture::PortAudioCaptureNode"
   EXECUTABLE audio_capture_portaudio_node
 )
+rclcpp_components_register_node(
+  ${PROJECT_NAME}
+  PLUGIN "audio_capture::PulseAudioCaptureNode"
+  EXECUTABLE audio_capture_pulseaudio_node
+)
 
 install(TARGETS audio_capture_node ${PROJECT_NAME}
   LIBRARY DESTINATION lib
@@ -54,6 +62,12 @@ install(TARGETS audio_capture_node ${PROJECT_NAME}
 )
 
 install(TARGETS audio_capture_portaudio_node ${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS audio_capture_pulseaudio_node ${PROJECT_NAME}
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
   RUNTIME DESTINATION bin

--- a/audio_capture/CMakeLists.txt
+++ b/audio_capture/CMakeLists.txt
@@ -20,7 +20,6 @@ pkg_check_modules(GST1.0 gstreamer-1.0 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS thread)
 pkg_check_modules(PORTAUDIO REQUIRED portaudio-2.0)
 pkg_check_modules(PULSE REQUIRED libpulse)
-pkg_check_modules(PULSE_SIMPLE REQUIRED libpulse-simple)
 
 add_library(${PROJECT_NAME} SHARED
   src/audio_capture_node.cpp
@@ -28,7 +27,7 @@ add_library(${PROJECT_NAME} SHARED
   src/pulse_audio_capture.cpp
 )
 
-target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS} ${PORTAUDIO_INCLUDE_DIRS} ${PULSE_INCLUDE_DIRS} ${PULSE_SIMPLE_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} PRIVATE ${Boost_INCLUDE_DIRS} ${GST1.0_INCLUDE_DIRS} ${PORTAUDIO_INCLUDE_DIRS} ${PULSE_INCLUDE_DIRS})
 ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
@@ -37,7 +36,7 @@ ament_target_dependencies(${PROJECT_NAME}
   diagnostic_updater
 )
 
-target_link_libraries(${PROJECT_NAME} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${PULSE_LIBRARIES} ${PULSE_SIMPLE_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${GST1.0_LIBRARIES} ${Boost_LIBRARIES} ${PORTAUDIO_LIBRARIES} ${PULSE_LIBRARIES})
 
 rclcpp_components_register_node(
   ${PROJECT_NAME}

--- a/audio_capture/package.xml
+++ b/audio_capture/package.xml
@@ -29,6 +29,7 @@
    <build_depend>libgstreamer1.0-dev</build_depend>
    <build_depend>libgstreamer-plugins-base1.0-dev</build_depend>
    <depend>portaudio19-dev</depend>
+   <depend>libpulse-dev</depend>
    <depend>rclcpp_lifecycle</depend>
 
    <exec_depend>audio_common_msgs</exec_depend>

--- a/audio_capture/src/pulse_audio_capture.cpp
+++ b/audio_capture/src/pulse_audio_capture.cpp
@@ -1,0 +1,226 @@
+/*********************************************************************
+ * Copyright (c) 2025 SoftBank Corp.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ********************************************************************/
+
+#include <pulse/error.h>
+#include <pulse/simple.h>
+#include <stdio.h>
+
+#include <boost/thread.hpp>
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/publisher.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_components/register_node_macro.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+#include "audio_common_msgs/msg/audio_data.hpp"
+#include "audio_common_msgs/msg/audio_data_stamped.hpp"
+#include "audio_common_msgs/msg/audio_info.hpp"
+
+namespace audio_capture
+{
+class PulseAudioCaptureNode : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  PulseAudioCaptureNode(const rclcpp::NodeOptions & options)
+  : rclcpp_lifecycle::LifecycleNode("audio_capture_node", options), updater_(this), _desired_rate(-1.0)
+  {
+    this->declare_parameter<std::string>("sample_format", "S16LE");
+
+    this->declare_parameter<int>("channels", 1);
+    this->declare_parameter<int>("sample_rate", 16000);
+    this->declare_parameter<int>("bitrate", 192);
+    this->declare_parameter<double>("desired_rate", 100.0);
+    this->declare_parameter<std::string>("source", "");
+
+    this->declare_parameter<double>("diagnostic_tolerance", 0.1);
+
+    this->get_parameter("desired_rate", _desired_rate);
+
+    _pub = this->create_publisher<audio_common_msgs::msg::AudioData>("audio", 10);
+    auto info_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local();
+    _pub_info = this->create_publisher<audio_common_msgs::msg::AudioInfo>("audio_info", info_qos);
+
+    rclcpp::Publisher<audio_common_msgs::msg::AudioDataStamped>::SharedPtr pub_stamped =
+      this->create_publisher<audio_common_msgs::msg::AudioDataStamped>("audio_stamped", 10);
+
+    auto tolerance = this->get_parameter("diagnostic_tolerance").as_double();
+
+    _last_publish_time_ = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
+
+    updater_.setHardwareID("microphone");
+    _diagnosed_pub_stamped =
+      std::make_shared<diagnostic_updater::DiagnosedPublisher<audio_common_msgs::msg::AudioDataStamped>>(
+        pub_stamped, updater_, diagnostic_updater::FrequencyStatusParam(&_desired_rate, &_desired_rate, tolerance, 10),
+        diagnostic_updater::TimeStampStatusParam());
+
+    _auto_recovery_timer =
+      create_wall_timer(std::chrono::duration<double>(1.0), [this] { autoRecoveryTrigger(); });
+  }
+
+  void publishInfo()
+  {
+    audio_common_msgs::msg::AudioInfo info_msg;
+    info_msg.channels = _channels;
+    info_msg.sample_rate = _sample_rate;
+    info_msg.sample_format = _sample_format;
+    info_msg.bitrate = _bitrate;
+    info_msg.coding_format = "raw";
+    _pub_info->publish(info_msg);
+  }
+
+  ~PulseAudioCaptureNode()
+  {
+  }
+
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+  auto on_configure(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
+    this->get_parameter("sample_format", _sample_format);
+    this->get_parameter("channels", _channels);
+    this->get_parameter("sample_rate", _sample_rate);
+    this->get_parameter("bitrate", _bitrate);
+    if (_sample_format == "S16LE") {
+      _sample_spec.format = PA_SAMPLE_S16LE;
+    } else if (_sample_format == "S32LE") {
+      _sample_spec.format = PA_SAMPLE_S32LE;
+    } else if (_sample_format == "U8") {
+      _sample_spec.format = PA_SAMPLE_U8;
+    } else if (_sample_format == "F32LE") {
+      _sample_spec.format = PA_SAMPLE_FLOAT32LE;
+    } else if (_sample_format == "S24LE") {
+      _sample_spec.format = PA_SAMPLE_S24LE;
+    } else {
+      RCLCPP_ERROR(this->get_logger(), "Unsupported sample format: %s", _sample_format.c_str());
+      return CallbackReturn::FAILURE;
+    }
+    _sample_spec.rate = static_cast<uint32_t>(_sample_rate);
+    _sample_spec.channels = static_cast<uint8_t>(_channels);
+
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_activate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    int error;
+    std::string source;
+    this->get_parameter("source", source);
+    _stream = pa_simple_new(
+      nullptr,
+      "pulse_capture_libpulse_node",
+      PA_STREAM_RECORD,
+      source.empty() ? nullptr : source.c_str(),
+      "record",
+      &_sample_spec,
+      nullptr,
+      nullptr,
+      &error);
+    if (!_stream) {
+      RCLCPP_ERROR(this->get_logger(), "pa_simple_new() failed: %s", pa_strerror(error));
+      return CallbackReturn::FAILURE;
+    }
+
+    _timer_info = rclcpp::create_timer(this, get_clock(), std::chrono::seconds(5), [this] { publishInfo(); });
+    publishInfo();
+    _record_timer = rclcpp::create_timer(
+      this, get_clock(), std::chrono::duration<double>(1.0 / _desired_rate), [this]() {
+        const size_t buffer_size = pa_frame_size(&_sample_spec) * _sample_spec.rate / _desired_rate;
+        std::vector<uint8_t> buffer(buffer_size);
+        int error;
+        if (pa_simple_read(_stream, buffer.data(), buffer.size(), &error) < 0) {
+          RCLCPP_ERROR(this->get_logger(), "pa_simple_read() failed: %s", pa_strerror(error));
+          trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+          return;
+        }
+        audio_common_msgs::msg::AudioData msg;
+        msg.data = buffer;
+        publish(msg);
+
+        audio_common_msgs::msg::AudioDataStamped stamped_msg;
+        stamped_msg.audio.data = msg.data;
+        stamped_msg.header.stamp = this->now();
+        _diagnosed_pub_stamped->publish(stamped_msg);
+
+        _last_publish_time_ = this->now();
+      });
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
+    if (_stream) {
+      pa_simple_free(_stream);
+      _stream = nullptr;
+    }
+    RCLCPP_INFO(this->get_logger(), "PortAudioCaptureNode deactivated, stream closed.");
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    _last_publish_time_ = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
+    return CallbackReturn::SUCCESS;
+  }
+  auto on_error(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+    if (_stream) {
+      pa_simple_free(_stream);
+      _stream = nullptr;
+    }
+    return CallbackReturn::SUCCESS;
+  }
+
+  void autoRecoveryTrigger()
+  {
+    if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED) {
+      trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CONFIGURE);
+    } else if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+      if (get_clock()->now() - _last_publish_time_ > rclcpp::Duration::from_seconds(1.0)) {
+        RCLCPP_WARN(this->get_logger(), "No audio data published for 1 second, deactivating.");
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
+      }
+    } else if (get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+      if (_last_publish_time_ != rclcpp::Time(0, 0, this->get_clock()->get_clock_type())) {
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_CLEANUP);
+      } else {
+        RCLCPP_INFO(this->get_logger(), "Reactivating.");
+        trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_ACTIVATE);
+      }
+    }
+  }
+
+  void publish(const audio_common_msgs::msg::AudioData & msg) { _pub->publish(msg); }
+
+  void publishStamped(const audio_common_msgs::msg::AudioDataStamped & msg) { _diagnosed_pub_stamped->publish(msg); }
+
+private:
+
+  rclcpp::Publisher<audio_common_msgs::msg::AudioData>::SharedPtr _pub;
+  rclcpp::Publisher<audio_common_msgs::msg::AudioInfo>::SharedPtr _pub_info;
+
+  rclcpp::TimerBase::SharedPtr _timer_info;
+  rclcpp::TimerBase::SharedPtr _record_timer;
+  rclcpp::TimerBase::SharedPtr _auto_recovery_timer;
+
+  pa_sample_spec _sample_spec;
+  pa_simple * _stream;
+  int _bitrate, _channels, _sample_rate;
+  std::string _sample_format;
+
+  diagnostic_updater::Updater updater_;
+  double _desired_rate;
+  std::shared_ptr<diagnostic_updater::DiagnosedPublisher<audio_common_msgs::msg::AudioDataStamped>>
+    _diagnosed_pub_stamped;
+  rclcpp::Time _last_publish_time_;
+};
+}  // namespace audio_capture
+
+RCLCPP_COMPONENTS_REGISTER_NODE(audio_capture::PulseAudioCaptureNode)

--- a/audio_capture/src/pulse_audio_capture.cpp
+++ b/audio_capture/src/pulse_audio_capture.cpp
@@ -1,31 +1,15 @@
-/*********************************************************************
- * Copyright (c) 2025 SoftBank Corp.
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *     http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * 
- ********************************************************************/
-
 #include <pulse/error.h>
-#include <pulse/simple.h>
-#include <stdio.h>
+#include <pulse/pulseaudio.h>
 
 #include <boost/thread.hpp>
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_updater/publisher.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
+#include <mutex>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <rclcpp_lifecycle/lifecycle_node.hpp>
+#include <vector>
 
 #include "audio_common_msgs/msg/audio_data.hpp"
 #include "audio_common_msgs/msg/audio_data_stamped.hpp"
@@ -33,11 +17,18 @@
 
 namespace audio_capture
 {
+
 class PulseAudioCaptureNode : public rclcpp_lifecycle::LifecycleNode
 {
 public:
   PulseAudioCaptureNode(const rclcpp::NodeOptions & options)
-  : rclcpp_lifecycle::LifecycleNode("audio_capture_node", options), updater_(this), _desired_rate(-1.0)
+  : rclcpp_lifecycle::LifecycleNode("audio_capture_node", options),
+    _mainloop(nullptr),
+    _context(nullptr),
+    _stream(nullptr),
+    _chunk_size_bytes(0),
+    updater_(this),
+    _desired_rate(-1.0)
   {
     this->declare_parameter<std::string>("sample_format", "S16LE");
 
@@ -51,7 +42,6 @@ public:
 
     this->get_parameter("desired_rate", _desired_rate);
 
-    _pub = this->create_publisher<audio_common_msgs::msg::AudioData>("audio", 10);
     auto info_qos = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local();
     _pub_info = this->create_publisher<audio_common_msgs::msg::AudioInfo>("audio_info", info_qos);
 
@@ -68,8 +58,12 @@ public:
         pub_stamped, updater_, diagnostic_updater::FrequencyStatusParam(&_desired_rate, &_desired_rate, tolerance, 10),
         diagnostic_updater::TimeStampStatusParam());
 
-    _auto_recovery_timer =
-      create_wall_timer(std::chrono::duration<double>(1.0), [this] { autoRecoveryTrigger(); });
+    _auto_recovery_timer = create_wall_timer(std::chrono::duration<double>(1.0), [this] { autoRecoveryTrigger(); });
+  }
+
+  ~PulseAudioCaptureNode()
+  {
+    cleanupPulse();
   }
 
   void publishInfo()
@@ -83,17 +77,15 @@ public:
     _pub_info->publish(info_msg);
   }
 
-  ~PulseAudioCaptureNode()
-  {
-  }
-
   using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
   auto on_configure(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
   {
     this->get_parameter("sample_format", _sample_format);
     this->get_parameter("channels", _channels);
     this->get_parameter("sample_rate", _sample_rate);
     this->get_parameter("bitrate", _bitrate);
+
     if (_sample_format == "S16LE") {
       _sample_spec.format = PA_SAMPLE_S16LE;
     } else if (_sample_format == "S32LE") {
@@ -108,73 +100,52 @@ public:
       RCLCPP_ERROR(this->get_logger(), "Unsupported sample format: %s", _sample_format.c_str());
       return CallbackReturn::FAILURE;
     }
+
     _sample_spec.rate = static_cast<uint32_t>(_sample_rate);
     _sample_spec.channels = static_cast<uint8_t>(_channels);
 
     return CallbackReturn::SUCCESS;
   }
-  auto on_activate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
-    int error;
+
+  auto on_activate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
     std::string source;
     this->get_parameter("source", source);
-    _stream = pa_simple_new(
-      nullptr,
-      "pulse_capture_libpulse_node",
-      PA_STREAM_RECORD,
-      source.empty() ? nullptr : source.c_str(),
-      "record",
-      &_sample_spec,
-      nullptr,
-      nullptr,
-      &error);
-    if (!_stream) {
-      RCLCPP_ERROR(this->get_logger(), "pa_simple_new() failed: %s", pa_strerror(error));
+
+    const auto frame_size = pa_frame_size(&_sample_spec);
+    auto frames_per_chunk = static_cast<std::size_t>(std::round(static_cast<double>(_sample_spec.rate) / _desired_rate));
+    if (frames_per_chunk == 0) {
+      frames_per_chunk = 1;
+    }
+    _chunk_size_bytes = frames_per_chunk * frame_size;
+
+    if (!initPulse(source)) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to initialize PulseAudio stream.");
       return CallbackReturn::FAILURE;
     }
 
     _timer_info = rclcpp::create_timer(this, get_clock(), std::chrono::seconds(5), [this] { publishInfo(); });
     publishInfo();
-    _record_timer = rclcpp::create_timer(
-      this, get_clock(), std::chrono::duration<double>(1.0 / _desired_rate), [this]() {
-        const size_t buffer_size = pa_frame_size(&_sample_spec) * _sample_spec.rate / _desired_rate;
-        std::vector<uint8_t> buffer(buffer_size);
-        int error;
-        if (pa_simple_read(_stream, buffer.data(), buffer.size(), &error) < 0) {
-          RCLCPP_ERROR(this->get_logger(), "pa_simple_read() failed: %s", pa_strerror(error));
-          trigger_transition(lifecycle_msgs::msg::Transition::TRANSITION_DEACTIVATE);
-          return;
-        }
-        audio_common_msgs::msg::AudioData msg;
-        msg.data = buffer;
-        publish(msg);
 
-        audio_common_msgs::msg::AudioDataStamped stamped_msg;
-        stamped_msg.audio.data = msg.data;
-        stamped_msg.header.stamp = this->now();
-        _diagnosed_pub_stamped->publish(stamped_msg);
-
-        _last_publish_time_ = this->now();
-      });
     return CallbackReturn::SUCCESS;
   }
+
   auto on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
   {
-    if (_stream) {
-      pa_simple_free(_stream);
-      _stream = nullptr;
-    }
-    RCLCPP_INFO(this->get_logger(), "PortAudioCaptureNode deactivated, stream closed.");
+    cleanupPulse();
+    RCLCPP_INFO(this->get_logger(), "PulseAudioCaptureNode deactivated, stream closed.");
     return CallbackReturn::SUCCESS;
   }
-  auto on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
+
+  auto on_cleanup(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
     _last_publish_time_ = rclcpp::Time(0, 0, this->get_clock()->get_clock_type());
     return CallbackReturn::SUCCESS;
   }
-  auto on_error(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override {
-    if (_stream) {
-      pa_simple_free(_stream);
-      _stream = nullptr;
-    }
+
+  auto on_error(const rclcpp_lifecycle::State & /*previous_state*/) -> CallbackReturn override
+  {
+    cleanupPulse();
     return CallbackReturn::SUCCESS;
   }
 
@@ -197,22 +168,24 @@ public:
     }
   }
 
-  void publish(const audio_common_msgs::msg::AudioData & msg) { _pub->publish(msg); }
-
-  void publishStamped(const audio_common_msgs::msg::AudioDataStamped & msg) { _diagnosed_pub_stamped->publish(msg); }
+  void publish(const audio_common_msgs::msg::AudioDataStamped & msg) { _diagnosed_pub_stamped->publish(msg); }
 
 private:
-
-  rclcpp::Publisher<audio_common_msgs::msg::AudioData>::SharedPtr _pub;
   rclcpp::Publisher<audio_common_msgs::msg::AudioInfo>::SharedPtr _pub_info;
 
   rclcpp::TimerBase::SharedPtr _timer_info;
-  rclcpp::TimerBase::SharedPtr _record_timer;
   rclcpp::TimerBase::SharedPtr _auto_recovery_timer;
 
-  pa_sample_spec _sample_spec;
-  pa_simple * _stream;
-  int _bitrate, _channels, _sample_rate;
+  pa_sample_spec _sample_spec{};
+  pa_threaded_mainloop * _mainloop;
+  pa_context * _context;
+  pa_stream * _stream;
+
+  std::size_t _chunk_size_bytes;
+  std::vector<uint8_t> _accum_buffer;
+  std::mutex _buffer_mutex;
+
+  int _bitrate{}, _channels{}, _sample_rate{};
   std::string _sample_format;
 
   diagnostic_updater::Updater updater_;
@@ -220,7 +193,220 @@ private:
   std::shared_ptr<diagnostic_updater::DiagnosedPublisher<audio_common_msgs::msg::AudioDataStamped>>
     _diagnosed_pub_stamped;
   rclcpp::Time _last_publish_time_;
+
+  static void contextStateCB(pa_context * c, void * userdata)
+  {
+    auto * node = static_cast<PulseAudioCaptureNode *>(userdata);
+    node->onContextStateChanged(c);
+  }
+
+  static void streamStateCB(pa_stream * s, void * userdata)
+  {
+    auto * node = static_cast<PulseAudioCaptureNode *>(userdata);
+    node->onStreamStateChanged(s);
+  }
+
+  static void streamReadCB(pa_stream * s, std::size_t length, void * userdata)
+  {
+    auto * node = static_cast<PulseAudioCaptureNode *>(userdata);
+    node->onStreamRead(s, length);
+  }
+
+  void onContextStateChanged(pa_context * c)
+  {
+    pa_context_state_t state = pa_context_get_state(c);
+    if (!PA_CONTEXT_IS_GOOD(state) && rclcpp::ok()) {
+      RCLCPP_ERROR(this->get_logger(), "PulseAudio context state error: %d", state);
+    }
+    if (_mainloop != nullptr) {
+      pa_threaded_mainloop_signal(_mainloop, 0);
+    }
+  }
+
+  void onStreamStateChanged(pa_stream * s)
+  {
+    pa_stream_state_t state = pa_stream_get_state(s);
+    if (!PA_STREAM_IS_GOOD(state) && rclcpp::ok()) {
+      RCLCPP_ERROR(this->get_logger(), "PulseAudio stream state error: %d", state);
+    }
+    if (_mainloop != nullptr) {
+      pa_threaded_mainloop_signal(_mainloop, 0);
+    }
+  }
+
+  void onStreamRead(pa_stream * s, std::size_t /*length*/)
+  {
+    const void * data = nullptr;
+    std::size_t bytes = 0;
+
+    if (pa_stream_peek(s, &data, &bytes) < 0) {
+      RCLCPP_ERROR_THROTTLE(this->get_logger(), *this->get_clock(), 1.0, "pa_stream_peek() failed");
+      return;
+    }
+
+    if (data == nullptr || bytes == 0) {
+      pa_stream_drop(s);
+      return;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(_buffer_mutex);
+      const uint8_t * src = static_cast<const uint8_t *>(data);
+      _accum_buffer.insert(_accum_buffer.end(), src, src + bytes);
+
+      while (_accum_buffer.size() >= _chunk_size_bytes && _chunk_size_bytes > 0 && rclcpp::ok()) {
+        audio_common_msgs::msg::AudioData msg;
+        msg.data.assign(_accum_buffer.begin(), _accum_buffer.begin() + static_cast<std::ptrdiff_t>(_chunk_size_bytes));
+
+        _accum_buffer.erase(
+          _accum_buffer.begin(), _accum_buffer.begin() + static_cast<std::ptrdiff_t>(_chunk_size_bytes));
+
+        audio_common_msgs::msg::AudioDataStamped stamped_msg;
+        stamped_msg.audio.data = msg.data;
+        stamped_msg.header.stamp = this->now();
+        publish(stamped_msg);
+
+        _last_publish_time_ = this->now();
+      }
+    }
+
+    pa_stream_drop(s);
+  }
+
+  bool initPulse(const std::string & source)
+  {
+    // Cleanup any existing PulseAudio resources
+    cleanupPulse();
+
+    _mainloop = pa_threaded_mainloop_new();
+    if (_mainloop == nullptr) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create PulseAudio mainloop");
+      return false;
+    }
+
+    pa_mainloop_api * api = pa_threaded_mainloop_get_api(_mainloop);
+    _context = pa_context_new(api, "PulseAudioCaptureNode");
+    if (_context == nullptr) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to create PulseAudio context");
+      cleanupPulse();
+      return false;
+    }
+
+    pa_context_set_state_callback(_context, &PulseAudioCaptureNode::contextStateCB, this);
+
+    pa_threaded_mainloop_lock(_mainloop);
+
+    if (pa_context_connect(_context, nullptr, PA_CONTEXT_NOFLAGS, nullptr) < 0) {
+      RCLCPP_ERROR(this->get_logger(), "pa_context_connect() failed: %s", pa_strerror(pa_context_errno(_context)));
+      pa_threaded_mainloop_unlock(_mainloop);
+      cleanupPulse();
+      return false;
+    }
+
+    // Start the mainloop
+    if (pa_threaded_mainloop_start(_mainloop) < 0) {
+      RCLCPP_ERROR(this->get_logger(), "pa_threaded_mainloop_start() failed");
+      pa_threaded_mainloop_unlock(_mainloop);
+      cleanupPulse();
+      return false;
+    }
+
+    // Wait for the context to be ready
+    while (rclcpp::ok()) {
+      pa_context_state_t state = pa_context_get_state(_context);
+      if (state == PA_CONTEXT_READY) {
+        break;
+      }
+      if (!PA_CONTEXT_IS_GOOD(state)) {
+        RCLCPP_ERROR(this->get_logger(), "PulseAudio context error state: %d", state);
+        pa_threaded_mainloop_unlock(_mainloop);
+        cleanupPulse();
+        return false;
+      }
+      pa_threaded_mainloop_wait(_mainloop);
+    }
+
+    // Create a new recording stream
+    _stream = pa_stream_new(_context, "record", &_sample_spec, nullptr);
+    if (_stream == nullptr) {
+      RCLCPP_ERROR(this->get_logger(), "pa_stream_new() failed: %s", pa_strerror(pa_context_errno(_context)));
+      pa_threaded_mainloop_unlock(_mainloop);
+      cleanupPulse();
+      return false;
+    }
+
+    pa_stream_set_state_callback(_stream, &PulseAudioCaptureNode::streamStateCB, this);
+    pa_stream_set_read_callback(_stream, &PulseAudioCaptureNode::streamReadCB, this);
+
+    pa_buffer_attr buffer_attr;
+    buffer_attr.maxlength = static_cast<uint32_t>(-1);
+    buffer_attr.tlength = static_cast<uint32_t>(-1);
+    buffer_attr.prebuf = static_cast<uint32_t>(-1);
+    buffer_attr.minreq = static_cast<uint32_t>(-1);
+    buffer_attr.fragsize = static_cast<uint32_t>(_chunk_size_bytes);
+
+    int flags = PA_STREAM_ADJUST_LATENCY;
+
+    if (
+      pa_stream_connect_record(
+        _stream, source.empty() ? nullptr : source.c_str(), &buffer_attr, static_cast<pa_stream_flags_t>(flags)) < 0) {
+      RCLCPP_ERROR(
+        this->get_logger(), "pa_stream_connect_record() failed: %s", pa_strerror(pa_context_errno(_context)));
+      pa_threaded_mainloop_unlock(_mainloop);
+      cleanupPulse();
+      return false;
+    }
+
+    // Wait for the stream to be ready
+    while (rclcpp::ok()) {
+      pa_stream_state_t sstate = pa_stream_get_state(_stream);
+      if (sstate == PA_STREAM_READY) {
+        break;
+      }
+      if (!PA_STREAM_IS_GOOD(sstate)) {
+        RCLCPP_ERROR(this->get_logger(), "PulseAudio stream error state: %d", sstate);
+        pa_threaded_mainloop_unlock(_mainloop);
+        cleanupPulse();
+        return false;
+      }
+      pa_threaded_mainloop_wait(_mainloop);
+    }
+
+    pa_threaded_mainloop_unlock(_mainloop);
+
+    return true;
+  }
+
+  void cleanupPulse()
+  {
+    if (_mainloop != nullptr) {
+      pa_threaded_mainloop_lock(_mainloop);
+    }
+
+    if (_stream != nullptr) {
+      pa_stream_disconnect(_stream);
+      pa_stream_unref(_stream);
+      _stream = nullptr;
+    }
+
+    if (_context != nullptr) {
+      pa_context_disconnect(_context);
+      pa_context_unref(_context);
+      _context = nullptr;
+    }
+
+    if (_mainloop != nullptr) {
+      pa_threaded_mainloop_unlock(_mainloop);
+      pa_threaded_mainloop_stop(_mainloop);
+      pa_threaded_mainloop_free(_mainloop);
+      _mainloop = nullptr;
+    }
+
+    std::lock_guard<std::mutex> lock(_buffer_mutex);
+    _accum_buffer.clear();
+  }
 };
+
 }  // namespace audio_capture
 
 RCLCPP_COMPONENTS_REGISTER_NODE(audio_capture::PulseAudioCaptureNode)

--- a/audio_capture/src/pulse_audio_capture.cpp
+++ b/audio_capture/src/pulse_audio_capture.cpp
@@ -1,3 +1,20 @@
+/*********************************************************************
+ * Copyright (c) 2025 SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ********************************************************************/
+
 #include <pulse/error.h>
 #include <pulse/pulseaudio.h>
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

pulseaudioのsourceから音声を取得できるように
`source`に`pactl list sources short` で得られるデバイス名を与えるとそのsourceの音源を取得
何も指定しなければデフォルトの入力デバイスの音源

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #10 

AECを利用するかはわからないのでoutputのmonitorは必須ではないが、
https://github.com/sbgisen/soar/issues/848 をlibpulseを使うことで回避できていそう(19時間は問題なく動作)なのでマイクの入力を拾うノードはこちらに置き換えたい

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

https://github.com/sbgisen/soar/tree/test/speaker-monitor
```bash
ros2 launch soar_bringup soar.launch.py
```

以下で波形を表示もできます
https://github.com/sbgisen/sbgisen_speech_recognition/tree/test/plot
```bash
ros2 run sbgisen_speech_recognition plot_waveform --ros-args -r ref:=/soar/head/speaker/audio_stamped -r mic:=/soar/head/mic/audio_stampe
```

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
